### PR TITLE
DBZ-3577 Support kafka topic based signals

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotContext.java
@@ -7,13 +7,18 @@ package io.debezium.connector.mysql;
 
 import static io.debezium.connector.mysql.GtidSet.GTID_DELIMITER;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.annotation.NotThreadSafe;
+import io.debezium.connector.mysql.signal.ExecuteSnapshotKafkaSignal;
 import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotContext;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
 import io.debezium.pipeline.spi.OffsetContext;
 
 @NotThreadSafe
@@ -22,6 +27,9 @@ public class MySqlReadOnlyIncrementalSnapshotContext<T> extends AbstractIncremen
     private static final Logger LOGGER = LoggerFactory.getLogger(MySqlReadOnlyIncrementalSnapshotContext.class);
     private GtidSet lowWatermark = null;
     private GtidSet highWatermark = null;
+    private Long signalOffset;
+    private final Queue<ExecuteSnapshotKafkaSignal> executeSnapshotSignals = new ConcurrentLinkedQueue<>();
+    public static final String SIGNAL_OFFSET = INCREMENTAL_SNAPSHOT_KEY + "_signal_offset";
 
     public MySqlReadOnlyIncrementalSnapshotContext() {
         this(true);
@@ -29,6 +37,13 @@ public class MySqlReadOnlyIncrementalSnapshotContext<T> extends AbstractIncremen
 
     public MySqlReadOnlyIncrementalSnapshotContext(boolean useCatalogBeforeSchema) {
         super(useCatalogBeforeSchema);
+    }
+
+    protected static <U> IncrementalSnapshotContext<U> init(MySqlReadOnlyIncrementalSnapshotContext<U> context, Map<String, ?> offsets) {
+        AbstractIncrementalSnapshotContext.init(context, offsets);
+        final Long signalOffset = (Long) offsets.get(SIGNAL_OFFSET);
+        context.setSignalOffset(signalOffset);
+        return context;
     }
 
     public static <U> MySqlReadOnlyIncrementalSnapshotContext<U> load(Map<String, ?> offsets) {
@@ -99,5 +114,31 @@ public class MySqlReadOnlyIncrementalSnapshotContext<T> extends AbstractIncremen
 
     public boolean serverUuidChanged() {
         return highWatermark.getUUIDSets().size() > 1;
+    }
+
+    public Long getSignalOffset() {
+        return signalOffset;
+    }
+
+    public void setSignalOffset(Long signalOffset) {
+        this.signalOffset = signalOffset;
+    }
+
+    public Map<String, Object> store(Map<String, Object> offset) {
+        Map<String, Object> snapshotOffset = super.store(offset);
+        snapshotOffset.put(SIGNAL_OFFSET, signalOffset);
+        return snapshotOffset;
+    }
+
+    public void enqueueDataCollectionsToSnapshot(List<String> dataCollectionIds, long signalOffset) {
+        executeSnapshotSignals.add(new ExecuteSnapshotKafkaSignal(dataCollectionIds, signalOffset));
+    }
+
+    public ExecuteSnapshotKafkaSignal getExecuteSnapshotSignals() {
+        return executeSnapshotSignals.poll();
+    }
+
+    public boolean hasExecuteSnapshotSignals() {
+        return !executeSnapshotSignals.isEmpty();
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/ExecuteSnapshotKafkaSignal.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/ExecuteSnapshotKafkaSignal.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.signal;
+
+import java.util.List;
+
+public class ExecuteSnapshotKafkaSignal {
+    private final List<String> dataCollections;
+    private final long signalOffset;
+
+    public ExecuteSnapshotKafkaSignal(List<String> dataCollections, long signalOffset) {
+        this.dataCollections = dataCollections;
+        this.signalOffset = signalOffset;
+    }
+
+    public List<String> getDataCollections() {
+        return dataCollections;
+    }
+
+    public long getSignalOffset() {
+        return signalOffset;
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/KafkaSignalThread.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/KafkaSignalThread.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.signal;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.connector.mysql.MySqlReadOnlyIncrementalSnapshotChangeEventSource;
+import io.debezium.document.Document;
+import io.debezium.document.DocumentReader;
+import io.debezium.pipeline.signal.ExecuteSnapshot;
+import io.debezium.schema.DataCollectionId;
+import io.debezium.util.Collect;
+import io.debezium.util.Threads;
+
+/**
+ * The class responsible for processing of signals delivered to Debezium via a dedicated Kafka topic.
+ * The signal message must have the following structure:
+ * <ul>
+ * <li>{@code id STRING} - the unique identifier of the signal sent, usually UUID, can be used for deduplication</li>
+ * <li>{@code type STRING} - the unique logical name of the code executing the signal</li>
+ * <li>{@code data STRING} - the data in JSON format that are passed to the signal code
+ * </ul>
+ */
+public class KafkaSignalThread<T extends DataCollectionId> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaSignalThread.class);
+
+    private final ExecutorService signalTopicListenerExecutor;
+    private final String topicName;
+    private final String connectorName;
+    private final Duration pollTimeoutMs;
+    private final MySqlReadOnlyIncrementalSnapshotChangeEventSource<T> eventSource;
+    private final KafkaConsumer<String, String> signalsConsumer;
+
+    public static final String CONFIGURATION_FIELD_PREFIX_STRING = "signal.";
+    private static final String CONSUMER_PREFIX = CONFIGURATION_FIELD_PREFIX_STRING + "consumer.";
+
+    public static final Field SIGNAL_TOPIC = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "kafka.topic")
+            .withDisplayName("Signal topic name")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("The name of the topic for the signals to the connector")
+            .withValidation(Field::isRequired);
+
+    public static final Field BOOTSTRAP_SERVERS = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "kafka.bootstrap.servers")
+            .withDisplayName("Kafka broker addresses")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("A list of host/port pairs that the connector will use for establishing the initial "
+                    + "connection to the Kafka cluster for retrieving signals to the connector."
+                    + "This should point to the same Kafka cluster used by the Kafka Connect process.")
+            .withValidation(Field::isRequired);
+
+    public static final Field SIGNAL_POLL_TIMEOUT_MS = Field.create(CONFIGURATION_FIELD_PREFIX_STRING
+            + "signal.kafka.poll.timeout.ms")
+            .withDisplayName("Poll timeout for kafka signals (ms)")
+            .withType(ConfigDef.Type.INT)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDescription("The number of milliseconds to wait while polling signals.")
+            .withDefault(100)
+            .withValidation(Field::isNonNegativeInteger);
+
+    public KafkaSignalThread(Class<? extends SourceConnector> connectorType, CommonConnectorConfig connectorConfig,
+                             MySqlReadOnlyIncrementalSnapshotChangeEventSource<T> eventSource) {
+        String signalName = "kafka-signal";
+        connectorName = connectorConfig.getLogicalName();
+        signalTopicListenerExecutor = Threads.newSingleThreadExecutor(connectorType, connectorName, signalName, true);
+        Configuration signalConfig = connectorConfig.getConfig().subset(CONFIGURATION_FIELD_PREFIX_STRING, false)
+                .edit()
+                .withDefault(KafkaSignalThread.SIGNAL_TOPIC, connectorName + "-signal")
+                .build();
+        this.eventSource = eventSource;
+        this.topicName = signalConfig.getString(SIGNAL_TOPIC);
+        this.pollTimeoutMs = Duration.ofMillis(signalConfig.getInteger(SIGNAL_POLL_TIMEOUT_MS));
+        String bootstrapServers = signalConfig.getString(BOOTSTRAP_SERVERS);
+        Configuration consumerConfig = signalConfig.subset(CONSUMER_PREFIX, true).edit()
+                .withDefault(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+                .withDefault(ConsumerConfig.CLIENT_ID_CONFIG, UUID.randomUUID().toString())
+                .withDefault(ConsumerConfig.GROUP_ID_CONFIG, signalName)
+                .withDefault(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, 1) // get even smallest message
+                .withDefault(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
+                .withDefault(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10000) // readjusted since 0.10.1.0
+                .withDefault(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .withDefault(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .build();
+        signalsConsumer = new KafkaConsumer<>(consumerConfig.asProperties());
+        LOGGER.info("Subscribing to signals topic '{}'", topicName);
+        signalsConsumer.assign(Collect.arrayListOf(new TopicPartition(topicName, 0)));
+    }
+
+    public void start() {
+        signalTopicListenerExecutor.submit(this::monitorSignals);
+    }
+
+    private void monitorSignals() {
+        while (true) {
+            // DBZ-1361 not using poll(Duration) to keep compatibility with AK 1.x
+            ConsumerRecords<String, String> recoveredRecords = signalsConsumer.poll(pollTimeoutMs.toMillis());
+            for (ConsumerRecord<String, String> record : recoveredRecords) {
+                try {
+                    processSignal(record);
+                }
+                catch (final InterruptedException e) {
+                    LOGGER.error("Signals processing was interrupted", e);
+                    signalsConsumer.close();
+                    return;
+                }
+                catch (final Exception e) {
+                    LOGGER.error("Skipped signal due to an error '{}'", record, e);
+                }
+            }
+        }
+    }
+
+    private void processSignal(ConsumerRecord<String, String> record) throws IOException, InterruptedException {
+        if (!connectorName.equals(record.key())) {
+            LOGGER.info("Signal key '{}' doesn't match the connector's name '{}'", record.key(), connectorName);
+            return;
+        }
+        String value = record.value();
+        LOGGER.trace("Processing signal: {}", value);
+        final Document jsonData = (value == null || value.isEmpty()) ? Document.create()
+                : DocumentReader.defaultReader().read(value);
+        String type = jsonData.getString("type");
+        Document data = jsonData.getDocument("data");
+        if (ExecuteSnapshot.NAME.equals(type)) {
+            executeSnapshot(data, record.offset());
+        }
+        else {
+            LOGGER.warn("Unknown signal type {}", type);
+        }
+    }
+
+    private void executeSnapshot(Document data, long signalOffset) {
+        final List<String> dataCollections = ExecuteSnapshot.getDataCollections(data);
+        if (dataCollections != null) {
+            ExecuteSnapshot.SnapshotType snapshotType = ExecuteSnapshot.getSnapshotType(data);
+            LOGGER.info("Requested '{}' snapshot of data collections '{}'", snapshotType, dataCollections);
+            if (snapshotType == ExecuteSnapshot.SnapshotType.INCREMENTAL) {
+                eventSource.enqueueDataCollectionNamesToSnapshot(dataCollections, signalOffset);
+            }
+        }
+    }
+
+    public void seek(long signalOffset) {
+        signalsConsumer.seek(new TopicPartition(topicName, 0), signalOffset + 1);
+    }
+}

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ReadOnlyIncrementalSnapshotIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ReadOnlyIncrementalSnapshotIT.java
@@ -5,13 +5,22 @@
  */
 package io.debezium.connector.mysql;
 
+import java.io.File;
 import java.sql.SQLException;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.fest.assertions.Assertions;
 import org.fest.assertions.MapAssert;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -19,20 +28,75 @@ import org.junit.rules.TestRule;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.junit.SkipTestDependingOnGtidModeRule;
 import io.debezium.connector.mysql.junit.SkipWhenGtidModeIs;
+import io.debezium.connector.mysql.signal.KafkaSignalThread;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.kafka.KafkaCluster;
+import io.debezium.util.Collect;
 import io.debezium.util.Testing;
 
 @SkipWhenGtidModeIs(value = SkipWhenGtidModeIs.GtidMode.OFF, reason = "Read only connection requires GTID_MODE to be ON")
 public class ReadOnlyIncrementalSnapshotIT extends IncrementalSnapshotIT {
 
+    private static KafkaCluster kafka;
+    private static final int PARTITION_NO = 0;
     public static final String EXCLUDED_TABLE = "b";
     @Rule
     public TestRule skipTest = new SkipTestDependingOnGtidModeRule();
 
+    @Before
+    public void before() throws SQLException {
+        super.before();
+        kafka.createTopic(getSignalsTopic(), 1, 1);
+    }
+
+    @BeforeClass
+    public static void startKafka() throws Exception {
+        File dataDir = Testing.Files.createTestingDirectory("signal_cluster");
+        Testing.Files.delete(dataDir);
+        kafka = new KafkaCluster().usingDirectory(dataDir)
+                .deleteDataPriorToStartup(true)
+                .deleteDataUponShutdown(true)
+                .addBrokers(1)
+                .withKafkaConfiguration(Collect.propertiesOf(
+                        "auto.create.topics.enable", "false",
+                        "zookeeper.session.timeout.ms", "20000"))
+                .startup();
+    }
+
+    @AfterClass
+    public static void stopKafka() {
+        if (kafka != null) {
+            kafka.shutdown();
+        }
+    }
+
     protected Configuration.Builder config() {
         return super.config()
                 .with(MySqlConnectorConfig.TABLE_EXCLUDE_LIST, DATABASE.getDatabaseName() + "." + EXCLUDED_TABLE)
-                .with(MySqlConnectorConfig.READ_ONLY_CONNECTION, true);
+                .with(MySqlConnectorConfig.READ_ONLY_CONNECTION, true)
+                .with(KafkaSignalThread.SIGNAL_TOPIC, getSignalsTopic())
+                .with(KafkaSignalThread.BOOTSTRAP_SERVERS, kafka.brokerList());
+    }
+
+    private String getSignalsTopic() {
+        return DATABASE.getDatabaseName() + "signals_topic";
+    }
+
+    protected void sendExecuteSnapshotKafkaSignal() throws ExecutionException, InterruptedException {
+        String signalValue = String.format(
+                "{\"type\":\"execute-snapshot\",\"data\": {\"data-collections\": [\"%s\"], \"type\": \"INCREMENTAL\"}}",
+                tableDataCollectionId());
+        final ProducerRecord<String, String> executeSnapshotSignal = new ProducerRecord<>(getSignalsTopic(), PARTITION_NO, SERVER_NAME, signalValue);
+
+        final Configuration signalProducerConfig = Configuration.create()
+                .withDefault(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.brokerList())
+                .withDefault(ProducerConfig.CLIENT_ID_CONFIG, "signals")
+                .withDefault(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                .withDefault(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                .build();
+        try (final KafkaProducer<String, String> producer = new KafkaProducer<>(signalProducerConfig.asProperties())) {
+            producer.send(executeSnapshotSignal).get();
+        }
     }
 
     @Test
@@ -42,12 +106,12 @@ public class ReadOnlyIncrementalSnapshotIT extends IncrementalSnapshotIT {
         populateTable();
         startConnector();
 
-        sendAdHocSnapshotSignal();
+        sendExecuteSnapshotKafkaSignal();
 
         Thread t = new Thread(() -> {
             try (JdbcConnection connection = databaseConnection()) {
                 connection.setAutoCommit(false);
-                for (int i = 0; true; i++) {
+                for (int i = 0; !Thread.interrupted(); i++) {
                     connection.executeWithoutCommitting(String.format("INSERT INTO %s (pk, aa) VALUES (%s, %s)",
                             EXCLUDED_TABLE,
                             i + ROW_COUNT + 1,
@@ -61,12 +125,16 @@ public class ReadOnlyIncrementalSnapshotIT extends IncrementalSnapshotIT {
         });
         t.setDaemon(true);
         t.setName("filtered-binlog-events-thread");
-        t.start();
-
-        final int expectedRecordCount = ROW_COUNT;
-        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(expectedRecordCount);
-        for (int i = 0; i < expectedRecordCount; i++) {
-            Assertions.assertThat(dbChanges).includes(MapAssert.entry(i + 1, i));
+        try {
+            t.start();
+            final int expectedRecordCount = ROW_COUNT;
+            final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(expectedRecordCount);
+            for (int i = 0; i < expectedRecordCount; i++) {
+                Assertions.assertThat(dbChanges).includes(MapAssert.entry(i + 1, i));
+            }
+        }
+        finally {
+            t.interrupt();
         }
     }
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -409,19 +409,53 @@ a|Records the completed snapshot in the connector offsets.
 
 include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
 
-===== Read-only Incremental snapshot
+==== Read-only Incremental snapshot
 
 The MySql connector supports Incremental snapshot with read-only connection to the database.
 It's achieved by using executed GTID set as high and low watermarks.
 The state of chunk's window gets updated by comparing GTIDs of binlog events or server's heartbeats against low and high watermarks.
 
-To switch to read-only implementation set {link-prefix}:#{link-mysql-connector}-property-read-only[read.only] to `true`.
+To switch to read-only implementation set {link-prefix}:{link-mysql-connector}#mysql-property-read-only[read.only] to `true`.
 
 .Prerequisites
 
 * {link-prefix}:{link-mysql-connector}#enable-mysql-gtids[`enable-mysql-gtids`]
 * If connector is reading from a replica, then for multithreaded replicas (replicas on which `replica_parallel_workers` is set to a value greater than 0)
 it's required to set `replica_preserve_commit_order=1` or `slave_preserve_commit_order=1`
+
+==== Ad-hoc read-only Incremental snapshot
+
+An alternative way to {link-prefix}:{link-signalling}[signalling table] mechanism to execute a new snapshot when the MySQL connection is read-only is to send a message to the Kafka topic configured with
+{link-prefix}:{link-mysql-connector}#mysql-property-signal-kafka-topic[signal.kafka.topic] property.
+
+The key of the Kafka message has to match the connector's name.
+
+The value is a json with `type` and `data` fields.
+
+The signal type is `execute-snapshot` and the `data` field must have the following fields:
+
+.Execute snapshot data fields
+[cols="2,2,6",options="header"]
+|===
+|Field | Default | Value
+
+|`type`
+|`incremental`
+| The type of the snapshot to be executed. Currently only `incremental` is supported. +
+See the next section for more details.
+
+|`data-collections`
+|_N/A_
+| An array of qualified names of table to be snapshotted. +
+The format of the names is the same as for {link-prefix}:#{context}-property-signal-data-collection[signal.data.collection] configuration option.
+
+|===
+
+An example of the execute-snapshot Kafka message:
+
+Key = `test_connector`
+
+Value = `{"type":"execute-snapshot","data": {"data-collections": ["schema1.table1", "schema1.table2"], "type": "INCREMENTAL"}}`
 
 ifdef::community[]
 
@@ -2599,6 +2633,42 @@ The name format is _database-name.table-name_.
 ==== {prodname} connector database history configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
+
+[id="debezium-{context}-connector-kafka-signals-configuration-properties"]
+==== {prodname} connector kafka signals configuration properties
+
+When MySQL connector is configured as read-only the alternative for the signalling table is the signals Kafka topic.
+
+{prodname} provides a set of `signal.*` properties that control how the connector interacts with the Kafka signals topic.
+
+The following table describes the `signal` properties.
+
+.Kafka signals configuration properties
+[cols="33%a,17%a,50%a",options="header",subs="+attributes"]
+|===
+|Property |Default |Description
+|[[{context}-property-signal-kafka-topic]]<<{context}-property-signal-kafka-topic, `+signal.kafka.topic+`>>
+|
+|The name of the Kafka topic that connector monitors for ad-hoc signals.
+
+|[[{context}-property-signal-kafka-bootstrap-servers]]<<{context}-property-signal-kafka-bootstrap-servers, `+signal.kafka.bootstrap.servers+`>>
+|
+|A list of host/port pairs that the connector uses for establishing an initial connection to the Kafka cluster. Each pair should point to the same Kafka cluster used by the Kafka Connect process.
+
+|[[{context}-property-signal-kafka-poll-timeout-ms]]<<{context}-property-signal-kafka-poll-timeout-ms, `+signal.kafka.poll.timeout.ms+`>>
+|`100`
+|An integer value that specifies the maximum number of milliseconds the connector should wait when polling signals. The default is 100ms.
+
+|===
+
+[id="debezium-{context}-connector-pass-through-signals-kafka-consumer-configuration-properties"]
+==== {prodname} connector pass-through signals Kafka consumer client configuration properties
+
+The {prodname} connector provides for pass-through configuration of the signals Kafka consumer.
+Pass-through signals properties begin with the prefix `signals.consumer.*`.
+For example, the connector passes properties such as `signal.consumer.security.protocol=SSL` to the Kafka consumer.
+
+As is the case with the xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[pass-through properties for database history clients], {prodname} strips the prefixes from the properties before it passes them to the Kafka signals consumer.
 
 [id="debezium-{context}-connector-pass-through-database-driver-configuration-properties"]
 ==== {prodname} connector pass-through database driver configuration properties


### PR DESCRIPTION
An alternative way to signalling table mechanism to execute an incremental snapshot using Kafka topic configured with `signal.kafka.topic` property when the MySQL connection is read-only.

https://issues.redhat.com/browse/DBZ-3577