### PR TITLE
Support schema changes during snapshot

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -1020,6 +1020,11 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
         return true;
     }
 
+    @Override
+    public boolean supportsSchemaChangesDuringIncrementalSnapshot() {
+        return true;
+    }
+
     private final Configuration config;
     private final SnapshotMode snapshotMode;
     private final SnapshotLockingMode snapshotLockingMode;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/IncrementalSnapshotIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/IncrementalSnapshotIT.java
@@ -14,10 +14,10 @@ import org.junit.Before;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
 import io.debezium.jdbc.JdbcConnection;
-import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotTest;
+import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotWithSchemaChangesSupportTest;
 import io.debezium.util.Testing;
 
-public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<MySqlConnector> {
+public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchemaChangesSupportTest<MySqlConnector> {
 
     protected static final String SERVER_NAME = "is_test";
     protected final UniqueDatabase DATABASE = new UniqueDatabase(SERVER_NAME, "incremental_snapshot_test").withDbHistoryPath(DB_HISTORY_PATH);
@@ -74,5 +74,49 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<MySql
     @Override
     protected String signalTableName() {
         return DATABASE.qualifiedTableName("debezium_signal");
+    }
+
+    @Override
+    protected String tableName(String table) {
+        return DATABASE.qualifiedTableName(table);
+    }
+
+    @Override
+    protected String alterColumnStatement(String table, String column, String type) {
+        return String.format("ALTER TABLE %s MODIFY COLUMN %s %s", table, column, type);
+    }
+
+    @Override
+    protected String alterColumnSetNotNullStatement(String table, String column, String type) {
+        return String.format("ALTER TABLE %s MODIFY COLUMN %s %s NOT NULL", table, column, type);
+    }
+
+    @Override
+    protected String alterColumnDropNotNullStatement(String table, String column, String type) {
+        return String.format("ALTER TABLE %s MODIFY COLUMN %s %s NULL", table, column, type);
+    }
+
+    @Override
+    protected String alterColumnSetDefaultStatement(String table, String column, String type, String defaultValue) {
+        return String.format("ALTER TABLE %s MODIFY COLUMN %s %s DEFAULT %s", table, column, type, defaultValue);
+    }
+
+    @Override
+    protected String alterColumnDropDefaultStatement(String table, String column, String type) {
+        return String.format("ALTER TABLE %s MODIFY COLUMN %s %s", table, column, type);
+    }
+
+    @Override
+    protected void executeRenameTable(JdbcConnection connection, String newTable) throws SQLException {
+        connection.setAutoCommit(false);
+        String query = String.format("RENAME TABLE %s to %s, %s to %s", tableName(), "old_table", newTable, tableName());
+        logger.info(query);
+        connection.executeWithoutCommitting(query);
+        connection.commit();
+    }
+
+    @Override
+    protected String createTableStatement(String newTable, String copyTable) {
+        return String.format("CREATE TABLE %s LIKE %s", newTable, copyTable);
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -9,6 +9,7 @@ package io.debezium.connector.postgresql;
 import java.sql.SQLException;
 import java.util.Map;
 
+import org.apache.kafka.connect.data.Struct;
 import org.fest.assertions.Assertions;
 import org.fest.assertions.MapAssert;
 import org.junit.After;
@@ -120,6 +121,7 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
                 expectedRecordCount,
                 x -> true,
                 k -> k.getInt32("pk1") * 1_000 + k.getInt32("pk2") * 100 + k.getInt32("pk3") * 10 + k.getInt32("pk4"),
+                record -> ((Struct) record.value()).getStruct("after").getInt32(valueFieldName()),
                 "test_server.s1.a4",
                 null);
         for (int i = 0; i < expectedRecordCount; i++) {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -445,6 +445,11 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     }
 
     @Override
+    public boolean supportsSchemaChangesDuringIncrementalSnapshot() {
+        return true;
+    }
+
+    @Override
     protected SourceInfoStructMaker<? extends AbstractSourceInfo> getSourceInfoStructMaker(Version version) {
         switch (version) {
             case V1:

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotIT.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.sqlserver;
 
 import java.sql.SQLException;
+import java.util.Arrays;
 
 import org.junit.After;
 import org.junit.Before;
@@ -16,10 +17,10 @@ import io.debezium.connector.sqlserver.SqlServerConnectorConfig.SnapshotMode;
 import io.debezium.connector.sqlserver.util.TestHelper;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.SkipTestRule;
-import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotTest;
+import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotWithSchemaChangesSupportTest;
 import io.debezium.util.Testing;
 
-public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<SqlServerConnector> {
+public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchemaChangesSupportTest<SqlServerConnector> {
 
     private SqlServerConnection connection;
 
@@ -73,14 +74,62 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<SqlSe
     }
 
     @Override
+    protected String tableName(String table) {
+        return "testDB.dbo." + table;
+    }
+
+    @Override
     protected String signalTableName() {
         return "dbo.debezium_signal";
+    }
+
+    @Override
+    protected String alterColumnStatement(String table, String column, String type) {
+        return String.format("ALTER TABLE %s ALTER COLUMN %s %s", table, column, type);
+    }
+
+    @Override
+    protected String alterColumnSetNotNullStatement(String table, String column, String type) {
+        return String.format("ALTER TABLE %s ALTER COLUMN %s %s NOT NULL", table, column, type);
+    }
+
+    @Override
+    protected String alterColumnDropNotNullStatement(String table, String column, String type) {
+        return String.format("ALTER TABLE %s ALTER COLUMN %s %s NULL", table, column, type);
+    }
+
+    @Override
+    protected String alterColumnSetDefaultStatement(String table, String column, String type, String defaultValue) {
+        return String.format("ALTER TABLE %s ADD CONSTRAINT df_%s DEFAULT %s FOR %s", table, column, defaultValue, column);
+    }
+
+    @Override
+    protected String alterColumnDropDefaultStatement(String table, String column, String type) {
+        return String.format("ALTER TABLE %s DROP CONSTRAINT df_%s", table, column);
+    }
+
+    @Override
+    protected void executeRenameTable(JdbcConnection connection, String newTable) throws SQLException {
+        TestHelper.disableTableCdc(connection, "a");
+        connection.setAutoCommit(false);
+        logger.info(String.format("exec sp_rename '%s', '%s'", tableName(), "old_table"));
+        connection.executeWithoutCommitting(String.format("exec sp_rename '%s', '%s'", tableName(), "old_table"));
+        logger.info(String.format("exec sp_rename '%s', '%s'", tableName(newTable), "a"));
+        connection.executeWithoutCommitting(String.format("exec sp_rename '%s', '%s'", tableName(newTable), "a"));
+        TestHelper.enableTableCdc(connection, "a", "a", Arrays.asList("pk", "aa", "c"));
+        connection.commit();
+    }
+
+    @Override
+    protected String createTableStatement(String newTable, String copyTable) {
+        return String.format("CREATE TABLE %s (pk int primary key, aa int)", newTable);
     }
 
     @Override
     protected Builder config() {
         return TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
-                .with(SqlServerConnectorConfig.SIGNAL_DATA_COLLECTION, "testDB.dbo.debezium_signal");
+                .with(SqlServerConnectorConfig.SIGNAL_DATA_COLLECTION, "testDB.dbo.debezium_signal")
+                .with(SqlServerConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 250);
     }
 }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -347,7 +347,7 @@ public class TestHelper {
      *            the source table columns that are to be included in the change table, may not be {@code null}
      * @throws SQLException if anything unexpected fails
      */
-    public static void enableTableCdc(SqlServerConnection connection, String tableName, String captureName, List<String> captureColumnList) throws SQLException {
+    public static void enableTableCdc(JdbcConnection connection, String tableName, String captureName, List<String> captureColumnList) throws SQLException {
         Objects.requireNonNull(tableName);
         Objects.requireNonNull(captureName);
         Objects.requireNonNull(captureColumnList);
@@ -363,7 +363,7 @@ public class TestHelper {
      *            the name of the table, may not be {@code null}
      * @throws SQLException if anything unexpected fails
      */
-    public static void disableTableCdc(SqlServerConnection connection, String name) throws SQLException {
+    public static void disableTableCdc(JdbcConnection connection, String name) throws SQLException {
         Objects.requireNonNull(name);
         String disableCdcForTableStmt = DISABLE_TABLE_CDC.replace(STATEMENTS_PLACEHOLDER, name);
         connection.execute(disableCdcForTableStmt);

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -619,6 +619,10 @@ public abstract class CommonConnectorConfig {
         return false;
     }
 
+    public boolean supportsSchemaChangesDuringIncrementalSnapshot() {
+        return false;
+    }
+
     @SuppressWarnings("unchecked")
     private List<CustomConverter<SchemaBuilder, ConvertedField>> getCustomConverters() {
         final String converterNameList = config.getString(CUSTOM_CONVERTERS);

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -276,10 +276,16 @@ public class EventDispatcher<T extends DataCollectionId> {
 
     public void dispatchTransactionCommittedEvent(Partition partition, OffsetContext offset) throws InterruptedException {
         transactionMonitor.transactionComittedEvent(partition, offset);
+        if (incrementalSnapshotChangeEventSource != null) {
+            incrementalSnapshotChangeEventSource.processTransactionCommittedEvent(partition, offset);
+        }
     }
 
     public void dispatchTransactionStartedEvent(Partition partition, String transactionId, OffsetContext offset) throws InterruptedException {
         transactionMonitor.transactionStartedEvent(partition, transactionId, offset);
+        if (incrementalSnapshotChangeEventSource != null) {
+            incrementalSnapshotChangeEventSource.processTransactionStartedEvent(partition, offset);
+        }
     }
 
     public void dispatchConnectorEvent(ConnectorEvent event) {

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
@@ -73,6 +73,10 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
      */
     private Object[] maximumKey;
 
+    private IncrementalSnapshotSchema schema;
+
+    private boolean schemaVerified;
+
     public AbstractIncrementalSnapshotContext(boolean useCatalogBeforeSchema) {
         this.useCatalogBeforeSchema = useCatalogBeforeSchema;
     }
@@ -211,6 +215,8 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
         lastEventKeySent = null;
         chunkEndPosition = null;
         maximumKey = null;
+        schema = null;
+        schemaVerified = false;
     }
 
     public void revertChunk() {
@@ -242,6 +248,29 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
 
     public Optional<Object[]> maximumKey() {
         return Optional.ofNullable(maximumKey);
+    }
+
+    @Override
+    public IncrementalSnapshotSchema getSchema() {
+        return schema;
+    }
+
+    @Override
+    public void setSchema(IncrementalSnapshotSchema schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public boolean isSchemaVerified() {
+        return schemaVerified;
+    }
+
+    @Override
+    public void setSchemaVerified(boolean schemaVerified) {
+        this.schemaVerified = schemaVerified;
+        if (schemaVerified) {
+            LOGGER.info("Schema verified {}", schema);
+        }
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
@@ -34,4 +34,10 @@ public interface IncrementalSnapshotChangeEventSource<T extends DataCollectionId
 
     default void processFilteredEvent(Partition partition, OffsetContext offsetContext) throws InterruptedException {
     }
+
+    default void processTransactionStartedEvent(Partition partition, OffsetContext offsetContext) throws InterruptedException {
+    }
+
+    default void processTransactionCommittedEvent(Partition partition, OffsetContext offsetContext) throws InterruptedException {
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
@@ -46,4 +46,12 @@ public interface IncrementalSnapshotContext<T> {
     Map<String, Object> store(Map<String, Object> offset);
 
     void revertChunk();
+
+    void setSchema(IncrementalSnapshotSchema schema);
+
+    IncrementalSnapshotSchema getSchema();
+
+    boolean isSchemaVerified();
+
+    void setSchemaVerified(boolean schemaVerified);
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotSchema.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotSchema.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot.incremental;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class IncrementalSnapshotSchema {
+    private final int columnCount;
+    private final ColumnSchema[] columnSchemas;
+
+    public IncrementalSnapshotSchema(ResultSetMetaData metaData) throws SQLException {
+        this.columnCount = metaData.getColumnCount();
+        columnSchemas = new ColumnSchema[columnCount];
+        for (int i = 1; i <= columnCount; i++) {
+            columnSchemas[i - 1] = new ColumnSchema(metaData.getColumnName(i),
+                    metaData.getColumnType(i),
+                    metaData.isNullable(i),
+                    metaData.getPrecision(i),
+                    metaData.getScale(i));
+        }
+    }
+
+    public class ColumnSchema {
+        String columnName;
+        int columnType;
+        int nullable;
+        int precision;
+        int scale;
+
+        public ColumnSchema(String columnName, int columnType, int nullable, int precision, int scale) {
+            this.columnName = columnName;
+            this.columnType = columnType;
+            this.nullable = nullable;
+            this.precision = precision;
+            this.scale = scale;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ColumnSchema that = (ColumnSchema) o;
+            return columnType == that.columnType && nullable == that.nullable && precision == that.precision && scale == that.scale && columnName.equals(that.columnName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(columnName, columnType, nullable, precision, scale);
+        }
+
+        @Override
+        public String toString() {
+            return "ColumnSchema{" +
+                    "columnName='" + columnName + '\'' +
+                    ", columnType=" + columnType +
+                    ", nullable=" + nullable +
+                    ", precision=" + precision +
+                    ", scale=" + scale +
+                    '}';
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IncrementalSnapshotSchema schema = (IncrementalSnapshotSchema) o;
+        return columnCount == schema.columnCount && Arrays.equals(columnSchemas, schema.columnSchemas);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(columnCount);
+        result = 31 * result + Arrays.hashCode(columnSchemas);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Schema{" +
+                "columnCount=" + columnCount +
+                ", columnSchemas=" + Arrays.toString(columnSchemas) +
+                '}';
+    }
+}

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -72,30 +72,31 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
     }
 
     protected Map<Integer, Integer> consumeMixedWithIncrementalSnapshot(int recordCount) throws InterruptedException {
-        return consumeMixedWithIncrementalSnapshot(recordCount, x -> true, null);
+        return consumeMixedWithIncrementalSnapshot(recordCount, record -> ((Struct) record.value()).getStruct("after").getInt32(valueFieldName()), x -> true, null);
     }
 
-    protected Map<Integer, Integer> consumeMixedWithIncrementalSnapshot(int recordCount,
-                                                                        Predicate<Map.Entry<Integer, Integer>> dataCompleted, Consumer<List<SourceRecord>> recordConsumer)
+    protected <V> Map<Integer, V> consumeMixedWithIncrementalSnapshot(int recordCount, Function<SourceRecord, V> valueConverter,
+                                                                      Predicate<Map.Entry<Integer, V>> dataCompleted,
+                                                                      Consumer<List<SourceRecord>> recordConsumer)
             throws InterruptedException {
-        return consumeMixedWithIncrementalSnapshot(recordCount, dataCompleted, k -> k.getInt32(pkFieldName()), topicName(), recordConsumer);
+        return consumeMixedWithIncrementalSnapshot(recordCount, dataCompleted, k -> k.getInt32(pkFieldName()), valueConverter, topicName(), recordConsumer);
     }
 
-    protected Map<Integer, Integer> consumeMixedWithIncrementalSnapshot(
-                                                                        int recordCount,
-                                                                        Predicate<Map.Entry<Integer, Integer>> dataCompleted,
-                                                                        Function<Struct, Integer> idCalculator,
-                                                                        String topicName,
-                                                                        Consumer<List<SourceRecord>> recordConsumer)
+    protected <V> Map<Integer, V> consumeMixedWithIncrementalSnapshot(int recordCount,
+                                                                      Predicate<Map.Entry<Integer, V>> dataCompleted,
+                                                                      Function<Struct, Integer> idCalculator,
+                                                                      Function<SourceRecord, V> valueConverter,
+                                                                      String topicName,
+                                                                      Consumer<List<SourceRecord>> recordConsumer)
             throws InterruptedException {
-        final Map<Integer, Integer> dbChanges = new HashMap<>();
+        final Map<Integer, V> dbChanges = new HashMap<>();
         int noRecords = 0;
         for (;;) {
             final SourceRecords records = consumeRecordsByTopic(1);
             final List<SourceRecord> dataRecords = records.recordsForTopic(topicName);
             if (records.allRecordsInOrder().isEmpty()) {
                 noRecords++;
-                Assertions.assertThat(noRecords).describedAs("Too many no data record results")
+                Assertions.assertThat(noRecords).describedAs(String.format("Too many no data record results, %d < %d", dbChanges.size(), recordCount))
                         .isLessThanOrEqualTo(MAXIMUM_NO_RECORDS_CONSUMES);
                 continue;
             }
@@ -105,7 +106,7 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
             }
             dataRecords.forEach(record -> {
                 final int id = idCalculator.apply((Struct) record.key());
-                final int value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+                final V value = valueConverter.apply(record);
                 dbChanges.put(id, value);
             });
             if (recordConsumer != null) {
@@ -120,6 +121,23 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
 
         Assertions.assertThat(dbChanges).hasSize(recordCount);
         return dbChanges;
+    }
+
+    protected Map<Integer, SourceRecord> consumeRecordsMixedWithIncrementalSnapshot(int recordCount) throws InterruptedException {
+        return consumeMixedWithIncrementalSnapshot(recordCount, Function.identity(), x -> true, null);
+    }
+
+    protected Map<Integer, Integer> consumeMixedWithIncrementalSnapshot(int recordCount, Predicate<Map.Entry<Integer, Integer>> dataCompleted,
+                                                                        Consumer<List<SourceRecord>> recordConsumer)
+            throws InterruptedException {
+        return consumeMixedWithIncrementalSnapshot(recordCount, record -> ((Struct) record.value()).getStruct("after").getInt32(valueFieldName()), dataCompleted,
+                recordConsumer);
+    }
+
+    protected Map<Integer, SourceRecord> consumeRecordsMixedWithIncrementalSnapshot(int recordCount, Predicate<Map.Entry<Integer, SourceRecord>> dataCompleted,
+                                                                                    Consumer<List<SourceRecord>> recordConsumer)
+            throws InterruptedException {
+        return consumeMixedWithIncrementalSnapshot(recordCount, Function.identity(), dataCompleted, recordConsumer);
     }
 
     protected String valueFieldName() {

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotWithSchemaChangesSupportTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotWithSchemaChangesSupportTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot.incremental;
+
+import static org.apache.kafka.connect.data.Schema.Type.INT32;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.jdbc.JdbcConnection;
+
+public abstract class AbstractIncrementalSnapshotWithSchemaChangesSupportTest<T extends SourceConnector> extends AbstractIncrementalSnapshotTest<T> {
+
+    protected abstract String tableName(String table);
+
+    protected abstract String alterColumnStatement(String table, String column, String type);
+
+    protected abstract String alterColumnSetNotNullStatement(String table, String column, String type);
+
+    protected abstract String alterColumnDropNotNullStatement(String table, String column, String type);
+
+    protected abstract String alterColumnSetDefaultStatement(String table, String column, String type, String defaultValue);
+
+    protected abstract String alterColumnDropDefaultStatement(String table, String column, String type);
+
+    protected abstract void executeRenameTable(JdbcConnection connection, String newTable) throws SQLException;
+
+    protected abstract String createTableStatement(String newTable, String copyTable);
+
+    @Test
+    public void schemaChanges() throws Exception {
+        Print.enable();
+
+        populateTable();
+        startConnector();
+
+        sendAdHocSnapshotSignal();
+
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.setAutoCommit(true);
+            connection.execute(String.format("INSERT INTO %s (pk, aa) VALUES (%s, %s)", tableName(), ROW_COUNT + 11, ROW_COUNT + 10));
+            connection.execute(alterColumnStatement(tableName(), "aa", "VARCHAR(5)"));
+            connection.execute(String.format("INSERT INTO %s (pk, aa) VALUES (%s, '%s')", tableName(), ROW_COUNT + 10, ROW_COUNT + 9));
+            for (int i = 0; i < 9 && !Thread.interrupted(); i += 3) {
+                connection.execute(String.format("ALTER TABLE %s ADD c INT", tableName()));
+                connection.execute(String.format("INSERT INTO %s (pk, aa, c) VALUES (%s, '%s', %s)", tableName(), i + ROW_COUNT + 1, i + ROW_COUNT, 1));
+                connection.execute(alterColumnStatement(tableName(), "c", "VARCHAR(5)"));
+                connection.execute(String.format("INSERT INTO %s (pk, aa, c) VALUES (%s, '%s', '%s')", tableName(), i + ROW_COUNT + 2, i + ROW_COUNT + 1, "1"));
+                connection.execute(String.format("ALTER TABLE %s DROP COLUMN c", tableName()));
+                connection.execute(String.format("INSERT INTO %s (pk, aa) VALUES (%s, '%s')", tableName(), i + ROW_COUNT + 3, i + ROW_COUNT + 2));
+            }
+        }
+
+        final int expectedRecordCount = ROW_COUNT + 11;
+        final Map<Integer, SourceRecord> dbChanges = consumeRecordsMixedWithIncrementalSnapshot(expectedRecordCount);
+        for (int i = 0; i < expectedRecordCount; i++) {
+            assertTrue(String.format("missing PK %d", i + 1), dbChanges.containsKey(i + 1));
+            SourceRecord record = dbChanges.get(i + 1);
+            final Schema.Type valueType = record.valueSchema().field("after").schema().field(valueFieldName()).schema().type();
+            if (valueType == INT32) {
+                final int value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+                assertEquals(i, value);
+            }
+            else {
+                String value = ((Struct) record.value()).getStruct("after").getString(valueFieldName());
+                assertEquals(Integer.toString(i), value);
+            }
+        }
+    }
+
+    @Test
+    public void renameTable() throws Exception {
+        Print.enable();
+
+        populateTable();
+        final String newTable = "new_table";
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.setAutoCommit(true);
+            connection.execute(createTableStatement(tableName(newTable), tableName()));
+            connection.execute(String.format("INSERT INTO %s SELECT * FROM %s", tableName(newTable), tableName()));
+            connection.execute(String.format("ALTER TABLE %s ADD c varchar(5)", tableName(newTable)));
+        }
+        startConnector();
+        sendAdHocSnapshotSignal();
+
+        final int updatedRowCount = 10;
+        final AtomicInteger recordCounter = new AtomicInteger();
+        final AtomicBoolean tableRenamed = new AtomicBoolean();
+        final Map<Integer, SourceRecord> dbChanges = consumeRecordsMixedWithIncrementalSnapshot(ROW_COUNT, x -> true,
+                x -> {
+                    if (recordCounter.addAndGet(x.size()) > 10 && !tableRenamed.get()) {
+                        try (JdbcConnection connection = databaseConnection()) {
+                            executeRenameTable(connection, newTable);
+                            connection.executeWithoutCommitting(
+                                    String.format("UPDATE %s SET c = 'c' WHERE pk >= %s", tableName(), ROW_COUNT - updatedRowCount));
+                            connection.commit();
+                        }
+                        catch (SQLException e) {
+                            throw new RuntimeException(e);
+                        }
+                        tableRenamed.set(true);
+                    }
+                });
+        for (int i = 0; i < ROW_COUNT - updatedRowCount; i++) {
+            assertTrue(dbChanges.containsKey(i + 1));
+            SourceRecord record = dbChanges.get(i + 1);
+            final int value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+            assertEquals(i, value);
+            if (((Struct) record.value()).schema().field("c") != null) {
+                final String c = ((Struct) record.value()).getStruct("after").getString("c");
+                assertNull(c);
+            }
+        }
+
+        for (int i = ROW_COUNT - updatedRowCount; i < ROW_COUNT; i++) {
+            assertTrue(dbChanges.containsKey(i + 1));
+            SourceRecord record = dbChanges.get(i + 1);
+            final int value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+            assertEquals(i, value);
+            final String c = ((Struct) record.value()).getStruct("after").getString("c");
+            assertEquals("c", c);
+        }
+    }
+
+    @Test
+    public void columnNullabilityChanges() throws Exception {
+        Print.enable();
+
+        populateTable();
+        final Configuration config = config().build();
+        startAndConsumeTillEnd(connectorClass(), config);
+        waitForConnectorToStart();
+
+        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        // there shouldn't be any snapshot records
+        assertNoRecordsToConsume();
+        sendAdHocSnapshotSignal();
+
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.setAutoCommit(false);
+            connection.execute(alterColumnSetNotNullStatement(tableName(), "aa", "INTEGER"));
+            connection.commit();
+
+            connection.execute(alterColumnDropNotNullStatement(tableName(), "aa", "INTEGER"));
+            connection.commit();
+
+            for (int i = 0; i < ROW_COUNT; i++) {
+                connection.executeWithoutCommitting(String.format("INSERT INTO %s (pk, aa) VALUES (%s, null)",
+                        tableName(),
+                        i + ROW_COUNT + 1));
+            }
+            connection.commit();
+        }
+        final int expectedRecordCount = ROW_COUNT * 2;
+        final Map<Integer, SourceRecord> dbChanges = consumeRecordsMixedWithIncrementalSnapshot(expectedRecordCount);
+
+        for (int i = 0; i < ROW_COUNT; i++) {
+            SourceRecord record = dbChanges.get(i + 1);
+            final int value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+            assertEquals(i, value);
+        }
+
+        for (int i = ROW_COUNT; i < 2 * ROW_COUNT; i++) {
+            SourceRecord record = dbChanges.get(i + 1);
+            final Integer value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+            assertNull(value);
+        }
+    }
+
+    @Test
+    public void columnDefaultChanges() throws Exception {
+        Print.enable();
+
+        populateTable();
+        final Configuration config = config().build();
+        startAndConsumeTillEnd(connectorClass(), config);
+        waitForConnectorToStart();
+
+        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        // there shouldn't be any snapshot records
+        assertNoRecordsToConsume();
+
+        sendAdHocSnapshotSignal();
+
+        final int expectedRecordCount = ROW_COUNT * 4;
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.setAutoCommit(false);
+            connection.execute(alterColumnSetDefaultStatement(tableName(), "aa", "INTEGER", "-6"));
+            connection.commit();
+
+            for (int i = 0; i < ROW_COUNT; i++) {
+                connection.executeWithoutCommitting(String.format("INSERT INTO %s (pk) VALUES (%s)",
+                        tableName(),
+                        i + ROW_COUNT + 1));
+            }
+            connection.commit();
+
+            connection.executeWithoutCommitting(alterColumnDropDefaultStatement(tableName(), "aa", "INTEGER"));
+            connection.executeWithoutCommitting(alterColumnSetDefaultStatement(tableName(), "aa", "INTEGER", "-9"));
+            connection.commit();
+            for (int i = 0; i < ROW_COUNT; i++) {
+                connection.executeWithoutCommitting(String.format("INSERT INTO %s (pk) VALUES (%s)",
+                        tableName(),
+                        i + 2 * ROW_COUNT + 1));
+            }
+            connection.commit();
+
+            connection.executeWithoutCommitting(alterColumnDropDefaultStatement(tableName(), "aa", "INTEGER"));
+            connection.commit();
+            for (int i = 0; i < ROW_COUNT; i++) {
+                connection.executeWithoutCommitting(String.format("INSERT INTO %s (pk) VALUES (%s)",
+                        tableName(),
+                        i + 3 * ROW_COUNT + 1));
+            }
+            connection.commit();
+        }
+        final Map<Integer, SourceRecord> dbChanges = consumeRecordsMixedWithIncrementalSnapshot(expectedRecordCount);
+
+        for (int i = 0; i < ROW_COUNT; i++) {
+            SourceRecord record = dbChanges.get(i + 1);
+            final int value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+            assertEquals(i, value);
+        }
+
+        for (int i = ROW_COUNT; i < 2 * ROW_COUNT; i++) {
+            SourceRecord record = dbChanges.get(i + 1);
+            final Integer value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+            assertNotNull("value is null at pk=" + (i + 1), value);
+            assertEquals(String.format("value is %d at pk = %d, expected -6", value, i + 1), -6, value, 0);
+        }
+
+        for (int i = 2 * ROW_COUNT; i < 3 * ROW_COUNT; i++) {
+            SourceRecord record = dbChanges.get(i + 1);
+            final Integer value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+            assertNotNull("value is null at pk=" + (i + 1), value);
+            assertEquals(String.format("value is %d at pk = %d, expected -9", value, i + 1), -9, value, 0);
+        }
+
+        for (int i = 3 * ROW_COUNT; i < 4 * ROW_COUNT; i++) {
+            SourceRecord record = dbChanges.get(i + 1);
+            final Integer value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+            assertNull("value is not null at pk=" + (i + 1), value);
+        }
+    }
+
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4196

Blocked by https://issues.redhat.com/browse/DBZ-4197 to make the schema changes integration tests pass faster. Temporarily included DBZ-4197 related commit to this PR

#### Implementation 

When incremental snapshot queries a database for the next chunk of rows, the rows have the table’s current schema. However, if the binlog stream is behind the in-memory representation the table’s schema may be different from the current schema. For connectors with historized schema the solution is to wait for the connector to receive the DDL event in the binlog stream and update the in-memory representation of the table’s schema. After that, the connector can use the cached table’s structure to produce the correct incremental snapshot chunk events.

In order to detect schema changes during the incremental snapshot, each chunk’s schema needs to be compared against the table’s schema saved in the incremental snapshot context. 

To capture the table’s schema at the beginning of the incremental snapshot the connector queries the database for the table’s schema between low and high watermarks just like it would query an incremental snapshot chunk. As soon as the connector gets a window close event from the binlog it means that the in-memory representation of the table’s schema is up to date with the schema that was captured at the beginning of the incremental snapshot. The connector queries the database one more time to verify that the table's schema didn’t change since the initial schema capture. If the schema has changed, then the process of capturing the incremental snapshot schema is repeated.
<img width="1209" alt="1" src="https://user-images.githubusercontent.com/553032/138471504-cb223299-b57f-4224-b796-8daf661ccfc2.png">

If the schema is the same then it gets marked as verified and is used for comparisons during the following chunks selections.

<img width="1178" alt="2" src="https://user-images.githubusercontent.com/553032/138533269-82dbc755-13f3-4a7e-86de-e669ac15df59.png">

When a chunk’s schema doesn’t match the schema saved in incremental snapshot context the connector drops the selected chunk, updates incremental snapshot schema in the snapshot context and re-reads the chunk after the current window is closed and the in-memory table’s schema is guaranteed to be updated with the DDL from the binlog stream.

<img width="1268" alt="3" src="https://user-images.githubusercontent.com/553032/138533306-f13412d3-ab5e-4d49-b4ac-8c240649a533.png">

_Since the incremental snapshot events are created during the pause in binlog processing and added into the binlog stream only after the window close event it’s possible that some binlog events preceding the chunk events have a more recent database schema than incremental snapshot events. If it’s critical to keep the schema change consistency in the binlog stream, then it can be achieved by triggering chunk re-read on DDL events in historized connectors._
